### PR TITLE
Add timeout to jobs

### DIFF
--- a/bin/reprox-find-data
+++ b/bin/reprox-find-data
@@ -5,6 +5,7 @@ from reprox import find_runs, core
 def main(targets,
          exclude_from_invalid_cmt_version,
          context_kwargs=None,
+         ignore_runs=tuple(),
          ) -> None:
     """
     Determine data to process
@@ -18,6 +19,7 @@ def main(targets,
         exclude_from_invalid_cmt_version=exclude_from_invalid_cmt_version,
         context_kwargs=context_kwargs,
         keep_detectors=args.detectors,
+        ignore_runs=ignore_runs,
     )
 
 
@@ -34,6 +36,7 @@ if __name__ == '__main__':
                              package=args.package,
                              config_kwargs=args.context_kwargs,
                              **args.context_config_kwargs,
-                             )
+                             ),
+         ignore_runs=args.ignore_runs,
          )
     core.log.info('Determine data done, bye bye')

--- a/reprox/core.py
+++ b/reprox/core.py
@@ -9,6 +9,8 @@ import grp
 import json
 import typing
 import inspect
+from strax import to_str_tuple
+
 
 reprox_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
@@ -128,6 +130,13 @@ def parse_args(description='nton reprocessing on dali',
         help='Target final data type to produce. Can be a list for multicore mode.'
     )
     parser.add_argument(
+        '--ignore_runs', '--ignore-runs',
+        dest='ignore_runs',
+        default=None,
+        nargs='*',
+        help='List of run ids to ignore'
+    )
+    parser.add_argument(
         '--force-non-admin', '--force_non_admin',
         action='store_true',
         dest='force_non_admin',
@@ -148,6 +157,9 @@ def parse_args(description='nton reprocessing on dali',
             f'{os.getlogin()}, you are not an admin so you probably don\'t'
             f' want to do a full reprocessing. In case you know what you are'
             f' doing add the "--force-non-admin" flag to you instructions')
+    if args.ignore_runs is not None:
+        args.ignore_runs = [f'{int(r):06}' for r in to_str_tuple(args.ignore_runs)]
+        log.warning(f'Ignoring {args.ignore_runs}')
     return args
 
 

--- a/reprox/reprocessing.ini
+++ b/reprox/reprocessing.ini
@@ -4,12 +4,14 @@
 base_folder = /dali/lgrandi/xenonnt/data_management_reprocessing/
 destination_folder = /dali/lgrandi/xenonnt/processed/
 runs_to_do = to_do_runs.csv
-context = xenonnt_v6
+context = xenonnt_v7
 cmt_version = global_v6
 package = cutax
 # set to 26800 for testing otherwise 17900
 minimum_run_number = 17900
 straxer_timeout_seconds = 1200
+# Should be seperated by ","
+include_detectors=tpc
 
 [display]
 progress_bar = True
@@ -30,4 +32,5 @@ logging_level = INFO
 submit_only = 0
 ram = 24000
 cpus_per_job = 4
+job_timeout_hours = 4
 container_tag=development

--- a/reprox/submit_jobs.py
+++ b/reprox/submit_jobs.py
@@ -205,6 +205,8 @@ def _make_job(run_name: ty.List[str],
             cpus_per_task=cpus_per_task,  # Almost never an issue, better ask for more RAM
             container=container,
             sbatch_file=sbatch_file,
+            # TODO - fix hardcoding
+            hours=2,
         ),
     )
 

--- a/reprox/submit_jobs.py
+++ b/reprox/submit_jobs.py
@@ -159,6 +159,7 @@ def _make_job(run_name: ty.List[str],
               container='xenonnt-development.simg',
               include_config: ty.Union[None, dict] = None,
               context_config_kwargs: ty.Union[None, dict] = None,
+              job_timeout_hours=int(core.config['processing']['job_timeout_hours'])
               ) -> ProcessingJob:
     rd = get_rundoc(run_name)
     source = rd.get('source', 'none')
@@ -205,8 +206,7 @@ def _make_job(run_name: ty.List[str],
             cpus_per_task=cpus_per_task,  # Almost never an issue, better ask for more RAM
             container=container,
             sbatch_file=sbatch_file,
-            # TODO - fix hardcoding
-            hours=2,
+            job_timeout_hours = job_timeout_hours,
         ),
     )
 


### PR DESCRIPTION
Somehow, strax-jobs just get stuck at some point. I'm not sure if it's the software or just the fact that I was running 800 jobs in parrallel. Nevertheless, jobs shouldn't take more than 2 hours generally, so we can add a timeout.

Still need to make this configurable though