### PR TITLE
run dependabot remote

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,18 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     assignees:
-      - jorana
+      - JoranAngevaare
   # Maintain the requirements requirements folder
   - package-ecosystem: "pip"
     directory: "/extra_requirements"
     schedule:
       # Check for updates to requirements every week
-      interval: "monthly"
+      interval: "daily"
     # Raise pull requests for version updates
     # to pip against the `develop` branch
-    target-branch: "development"
+    target-branch: "master"
     open-pull-requests-limit: 15
     assignees:
-      - jorana
+      - JoranAngevaare

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,11 +1,3 @@
-coverage==6.3.2
-coveralls==3.3.1
-flake8==4.0.1
-hypothesis==6.39.0
-matplotlib==3.5.1
-numpy==1.21.2
-pandas==1.4.1
-pytest==7.0.1
-strax==1.1.7
-straxen==1.3.0
-utilix==0.6.6
+git+https://github.com/XENONnT/ax_env
+strax==1.2.0
+straxen==1.6.0


### PR DESCRIPTION
Run dependabot in a dedicated [repo](https://github.com/XENONnT/ax_env) to avoid tracking all dependencies for strax(en) etc several times

_PR family_:
- https://github.com/AxFoundation/strax/pull/683
- https://github.com/XENONnT/straxen/pull/1008
- https://github.com/XENONnT/pema/pull/204
- https://github.com/XENONnT/WFSim/pull/358
- https://github.com/XENONnT/reprox/pull/54