### PR TITLE
Context config debugged

### DIFF
--- a/bin/reprox-start-jobs
+++ b/bin/reprox-start-jobs
@@ -43,7 +43,7 @@ if __name__ == '__main__':
              ram=int(args.ram),
              cpus_per_task=int(args.cpu),
              container=f'xenonnt-{args.tag}.simg',
-             include_config=args.context_config_kwargs,
-             context_config_kwargs=args.context_kwargs,
+             include_config=args.context_kwargs,
+             context_config_kwargs=args.context_config_kwargs,
          ))
     core.log.info('Job submission done done, bye bye')

--- a/reprox/core.py
+++ b/reprox/core.py
@@ -12,7 +12,7 @@ import inspect
 from strax import to_str_tuple
 
 
-reprox_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))) # type: ignore
+reprox_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
 if 'REPROX_CONFIG' in os.environ:
     config_path = os.environ['REPROX_CONFIG']

--- a/reprox/core.py
+++ b/reprox/core.py
@@ -12,7 +12,7 @@ import inspect
 from strax import to_str_tuple
 
 
-reprox_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+reprox_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))) # type: ignore
 
 if 'REPROX_CONFIG' in os.environ:
     config_path = os.environ['REPROX_CONFIG']
@@ -80,6 +80,7 @@ def get_context(package=config['context']['package'],
                 config_kwargs: typing.Union[None, dict] = None,
                 minimum_run_number=config['context']['minimum_run_number'],
                 maximum_run_number=config['context']['maximum_run_number'],
+                **kwargs,
                 ):
     module = importlib.import_module(f'{package}.contexts')
 
@@ -113,6 +114,7 @@ def get_context(package=config['context']['package'],
                                       minimum_run_number=minimum_run_number,
                                       maximum_run_number=maximum_run_number,
                                   ),
+                                  **kwargs,
                                   )
     if config_kwargs is not None:
         log.warning(f'Updating the context with the following config {config_kwargs}')

--- a/reprox/find_runs.py
+++ b/reprox/find_runs.py
@@ -84,7 +84,6 @@ def determine_data_to_reprocess(
         run_mode = None
     else:
         run_mode = run_mode.split(',')
-
     # In case select_runs failed due to weird reasons, try again
     try:
         runs = st.select_runs(exclude_tags=('messy', 'bad', 'abandoned'), 

--- a/reprox/reprocessing.ini
+++ b/reprox/reprocessing.ini
@@ -35,7 +35,7 @@ max_jobs = 100
 logging_level = INFO
 # 0 means submit everything
 submit_only = 0
-ram = 5000
+ram = 20000
 cpus_per_job = 2
 job_timeout_hours = 8
 container_tag=2023.05.2


### PR DESCRIPTION
There is a mistake introduced in `reprox-start-jobs` in #109, and it has been fixed. Now the following combo works:
```
~/software/reprox/bin/reprox-find-data --context xenonnt_on
line --config-kwargs '{"_rucio_local_path":"/project/lgrandi/rucio","include_rucio_local":"true","output_folder":"/project2/lgrandi/xenonnt/processed"}' --targets cuts_basic
~/software/reprox/bin/reprox-start-jobs --context xenonnt_on
line --config-kwargs '{"_rucio_local_path":"/project/lgrandi/rucio","include_rucio_local":"true","output_folder":"/project2/lgrandi/xenonnt/processed"}' --targets cuts_basic
```